### PR TITLE
Refresh jobs to the upstream state of the pipeline and fixes

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -38,4 +38,5 @@
   logs
   cmdliner
   dockerfile
-  conf-libev))
+  conf-libev)
+ (conflicts (gitlab-unix (= "0.1.1"))))

--- a/src/analysis/tezos_repository.mli
+++ b/src/analysis/tezos_repository.mli
@@ -11,7 +11,10 @@ module Active_protocol : sig
 end
 
 module Version : sig
-  type t = { build_deps_image_version : string }
+  type t = {
+    build_deps_image_version : string;
+    recommended_node_version : string;
+  }
 end
 
 type t = {

--- a/src/stages/build.ml
+++ b/src/stages/build.ml
@@ -42,6 +42,7 @@ let v (tezos_repository : Analysis.Tezos_repository.t) =
             ~dst:"./";
           (* TODO: copy the subset of /src that is actually useful *)
           copy ~from:(`Build "build_src") [ "/tezos/src" ] ~dst:"src";
+          copy ~from:(`Build "build_src") [ "/tezos/tezt" ] ~dst:"tezt";
           copy ~from:(`Build "build_src") [ "/tezos/vendors" ] ~dst:"vendors";
           copy ~from:(`Build "build_src") [ "/tezos/.git" ] ~dst:".git";
           copy ~from:(`Build "build_src")

--- a/src/stages/build.ml
+++ b/src/stages/build.ml
@@ -56,10 +56,11 @@ let v (tezos_repository : Analysis.Tezos_repository.t) =
           env "DUNE_CACHE_TRANSPORT" "direct";
           run ~cache "opam exec -- dune build @runtest_dune_template";
           (* 2. Actually build and extract _build/default/src/lib_protocol_compiler/main_native.exe from the cached folder *)
-          run ~cache
-            "opam exec -- make all build-test && mkdir dist && cp --parents \
-             tezos-* src/proto_*/parameters/*.json \
-             _build/default/src/lib_protocol_compiler/main_native.exe dist";
+          run ~cache "opam exec -- make all build-test";
+          run ~cache "opam exec -- dune build src/bin_tps_evaluation";
+          run
+            "mkdir dist && cp --parents tezos-* src/proto_*/parameters/*.json \
+             _build/default/src/lib_protocol_compiler/bin/main_native.exe dist";
         ])
   in
   Obuilder_spec.(

--- a/src/stages/doc.ml
+++ b/src/stages/doc.ml
@@ -14,6 +14,9 @@ let build ~builder (analysis : Tezos_repository.t Current.t) =
           user ~uid:100 ~gid:100;
           workdir "/home/tezos";
           copy ~from:(`Build "src") [ "/tezos" ] ~dst:".";
+          run
+            "sed -i 's@:file:.*[.]html@:file: /dev/null@' \
+             ./docs/*/cli-commands.rst";
           run "opam exec -- make -C docs html";
         ])
     |> Current_ocluster.Artifacts.extract ~folder:"/home/tezos/docs"

--- a/src/stages/tezt.ml
+++ b/src/stages/tezt.ml
@@ -1,7 +1,7 @@
 open Analysis
 open Lib
 
-let tezt_job_total = 3
+let tezt_job_total = 25
 
 let template ~tezt_job analysis =
   let build = Build.v analysis in
@@ -22,7 +22,7 @@ let template ~tezt_job analysis =
         run
           "opam exec -- dune exec tezt/tests/main.exe -- --color \
            --log-buffer-size 5000 --log-file tezt.log --global-timeout 3300 \
-           --junit tezt-junit.xml --from-record tezt/test-results.json --job \
+           --junit tezt-junit.xml --from-record tezt/records --job \
            %d/%d --record tezt-results-%d.json"
           tezt_job tezt_job_total tezt_job;
         run "cat tezt.log";

--- a/src/website/website.ml
+++ b/src/website/website.ml
@@ -149,8 +149,8 @@ module Website_description = struct
           [
             txt "Source code on Github: ";
             a
-              ~a:[ a_href "https://github.com/ocurrent/tezos-ci" ]
-              [ txt "ocurrent/tezos-ci" ];
+              ~a:[ a_href "https://github.com/tarides/tezos-ci" ]
+              [ txt "tarides/tezos-ci" ];
           ];
       ]
 end

--- a/tezos-ci.opam
+++ b/tezos-ci.opam
@@ -29,6 +29,9 @@ depends: [
   "conf-libev"
   "odoc" {with-doc}
 ]
+conflicts: [
+  "gitlab-unix" {= "0.1.1"}
+]
 build: [
   ["dune" "subst"] {dev}
   [


### PR DESCRIPTION
- Point to `tarides/tezos-ci` instead of `ocurrent/tezos-ci` in the index page
- Fix off by one the displayed month date in current-web-pipelines
- Fix build stage
- Fix js unit tests by installing node