### PR TITLE
Adds support for rebuilding a pipeline.

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,5 +1,5 @@
 version = 0.21.0
-ocaml-version = 4.08
+ocaml-version = 4.10.0
 profile = conventional
 break-infix = fit-or-vertical
 parse-docstrings = true

--- a/dune-project
+++ b/dune-project
@@ -19,7 +19,7 @@
  (description "A longer description")
  (depends
   (ocaml
-   (>= 4.08.0))
+   (>= 4.10.0))
   dune-build-info
   (current
    (>= 0.6))

--- a/src/tezos_ci.ml
+++ b/src/tezos_ci.ml
@@ -112,7 +112,7 @@ let main () current_config mode gitlab (`Ocluster_cap cap) =
       Routes.(
         (s "webhooks" / s "gitlab" /? nil)
         @--> Gitlab.webhook ~webhook_secret:(Gitlab.Api.webhook_secret gitlab))
-      :: Website.routes index
+      :: Website.routes index engine
       @ Current_web.routes engine
     in
     Current_web.Site.(v ~has_role:allow_all) ~name:program_name routes

--- a/src/tezos_ci_local.ml
+++ b/src/tezos_ci_local.ml
@@ -46,7 +46,7 @@ let main () current_config mode (`Ocluster_cap cap) =
         pipeline ~index ocluster)
   in
   let site =
-    let routes = Website.routes index @ Current_web.routes engine in
+    let routes = Website.routes index engine @ Current_web.routes engine in
     Current_web.Site.(v ~has_role:allow_all) ~name:program_name routes
   in
   Logging.run

--- a/tezos-ci.opam
+++ b/tezos-ci.opam
@@ -8,7 +8,7 @@ homepage: "https://github.com/ocurrent/tezos-ci"
 bug-reports: "https://github.com/ocurrent/tezos-ci/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.08.0"}
+  "ocaml" {>= "4.10.0"}
   "dune-build-info"
   "current" {>= "0.6"}
   "current_web"


### PR DESCRIPTION
Closes #23 

Requires https://github.com/tarides/current-web-pipelines/pull/3 to be merged and the git submodule references to be reset to `main`