### PR TITLE
Synchronize with upstream

### DIFF
--- a/src/analysis/tezos_repository.ml
+++ b/src/analysis/tezos_repository.ml
@@ -112,8 +112,7 @@ type t = {
   all_protocols : string list;
   active_protocols : Active_protocol.t list;
   active_testing_protocol_versions : string list;
-  lib_packages : string list;
-  bin_packages : string list;
+  packages : string list;
   version : Version.t;
 }
 [@@deriving yojson]
@@ -150,25 +149,13 @@ let make ~commit repo_path =
   Bos.OS.Dir.with_current repo_path
     (fun () ->
       (* opam-pin.sh *)
-      let* opams_vendors = find_opam Fpath.(v "vendors") in
-      let* opams_src = find_opam (Fpath.v "src") in
-      let opams = opams_vendors @ opams_src in
-      let bin_packages, lib_packages =
-        List.partition
-          (fun path ->
-            let dir, _ = Fpath.split_base path in
-            Fpath.to_string dir |> Astring.String.is_infix ~affix:"/bin_")
-          opams
-      in
-      let bin_packages =
-        List.map
-          (fun path -> Fpath.split_base path |> snd |> Fpath.to_string)
-          bin_packages
-      in
-      let lib_packages =
-        List.map
-          (fun path -> Fpath.split_base path |> snd |> Fpath.to_string)
-          lib_packages
+      (* let* opams_vendors = find_opam Fpath.(v "vendors") in *)
+      let* opams_src = find_opam (Fpath.v "opam") in
+      let packages =
+        (* opams_vendors @  *)
+        opams_src
+        |> List.map (fun path ->
+               Fpath.split_base path |> snd |> Fpath.to_string)
       in
       (* remove-old-protocols.sh *)
       let* all_protocols = find_all_protocols () in
@@ -193,8 +180,7 @@ let make ~commit repo_path =
           all_protocols;
           active_testing_protocol_versions;
           active_protocols;
-          bin_packages;
-          lib_packages;
+          packages;
           version;
         })
     ()

--- a/src/analysis/tezos_repository.ml
+++ b/src/analysis/tezos_repository.ml
@@ -149,10 +149,8 @@ let make ~commit repo_path =
   Bos.OS.Dir.with_current repo_path
     (fun () ->
       (* opam-pin.sh *)
-      (* let* opams_vendors = find_opam Fpath.(v "vendors") in *)
       let* opams_src = find_opam (Fpath.v "opam") in
       let packages =
-        (* opams_vendors @  *)
         opams_src
         |> List.map (fun path ->
                Fpath.split_base path |> snd |> Fpath.to_string)

--- a/src/analysis/tezos_repository.mli
+++ b/src/analysis/tezos_repository.mli
@@ -25,8 +25,7 @@ type t = {
   active_testing_protocol_versions : string list;
       (** Active_testing_protocol_versions according to the
           /active_testing_protocol_versions file *)
-  lib_packages : string list;  (** List of library packages *)
-  bin_packages : string list;  (** List of binary packages *)
+  packages : string list;  (** List of packages *)
   version : Version.t;  (** Content of /scripts/version.sh *)
 }
 

--- a/src/stages/build.ml
+++ b/src/stages/build.ml
@@ -18,10 +18,10 @@ let v (tezos_repository : Analysis.Tezos_repository.t) =
       stage ~from
         ~child_builds:[ ("build_src", Lib.Fetch.spec tezos_repository) ]
         [
-          user ~uid:100 ~gid:100;
+          user ~uid:1000 ~gid:1000;
           env "HOME" "/home/tezos";
           workdir "/tezos/";
-          run "sudo chown 100:100 /tezos/";
+          run "sudo chown 1000:1000 /tezos/";
           copy ~from:(`Build "build_src")
             [ "/tezos/scripts/version.sh" ]
             ~dst:"./scripts/version.sh";

--- a/src/stages/coverage.ml
+++ b/src/stages/coverage.ml
@@ -17,7 +17,7 @@ let template analysis =
     stage ~from
       ~child_builds:[ ("build", build); ("src", Lib.Fetch.spec analysis) ]
       [
-        user ~uid:100 ~gid:100;
+        user ~uid:1000 ~gid:1000; 
         workdir "/tezos/";
         copy ~from:(`Build "src") [ "/tezos/" ] ~dst:".";
         copy ~from:(`Build "build") [ "/dist/" ] ~dst:".";

--- a/src/stages/doc.ml
+++ b/src/stages/doc.ml
@@ -11,7 +11,7 @@ let build ~builder (analysis : Tezos_repository.t Current.t) =
       stage ~from
         ~child_builds:[ ("src", Lib.Fetch.spec analysis) ]
         [
-          user ~uid:100 ~gid:100;
+          user ~uid:1000 ~gid:1000; 
           workdir "/home/tezos";
           copy ~from:(`Build "src") [ "/tezos" ] ~dst:".";
           run
@@ -33,7 +33,7 @@ let build_all ~builder (analysis : Tezos_repository.t Current.t) =
       stage ~from
         ~child_builds:[ ("src", Lib.Fetch.spec analysis) ]
         [
-          user ~uid:100 ~gid:100;
+          user ~uid:1000 ~gid:1000; 
           workdir "/home/tezos";
           copy ~from:(`Build "src") [ "/tezos" ] ~dst:".";
           run "opam exec -- make -C docs all";
@@ -52,7 +52,7 @@ let linkcheck ~builder (analysis : Tezos_repository.t Current.t) =
       stage ~from
         ~child_builds:[ ("src", Lib.Fetch.spec analysis) ]
         [
-          user ~uid:100 ~gid:100;
+          user ~uid:1000 ~gid:1000; 
           workdir "/home/tezos";
           copy ~from:(`Build "src") [ "/tezos" ] ~dst:".";
           run "opam exec -- make -C docs all";

--- a/src/stages/integration.ml
+++ b/src/stages/integration.ml
@@ -12,7 +12,7 @@ let template ~script analysis =
     stage ~from
       ~child_builds:[ ("build", build); ("src", Lib.Fetch.spec analysis) ]
       [
-        user ~uid:100 ~gid:100;
+        user ~uid:1000 ~gid:1000; 
         workdir "/home/tezos/src";
         copy ~from:(`Build "src") [ "/tezos/" ] ~dst:".";
         copy ~from:(`Build "build") [ "/dist/" ] ~dst:".";

--- a/src/stages/integration.ml
+++ b/src/stages/integration.ml
@@ -35,8 +35,7 @@ let pytest ~tezt_job =
 
 let examples =
   let script =
-    {|PYTHONPATH=\$PYTHONPATH:./ poetry run python examples/forge_transfer.py &&
-    PYTHONPATH=\$PYTHONPATH:./ poetry run python examples/example.py && 
+    {|PYTHONPATH=\$PYTHONPATH:./ poetry run python examples/example.py && 
     PYTHONPATH=./ poetry run pytest --exitfirst examples/test_example.py |}
   in
   template ~script

--- a/src/stages/lints.ml
+++ b/src/stages/lints.ml
@@ -11,7 +11,7 @@ let sanity_ci ~builder (analysis : Analysis.Tezos_repository.t Current.t) =
       stage ~from
         ~child_builds:[ ("build", build); ("src", Lib.Fetch.spec analysis) ]
         [
-          user ~uid:100 ~gid:100;
+          user ~uid:1000 ~gid:1000; 
           workdir "/home/tezos";
           copy ~from:(`Build "src") [ "/tezos/" ] ~dst:".";
           copy ~from:(`Build "build") [ "/dist/" ] ~dst:".";
@@ -53,7 +53,7 @@ let misc_checks ~builder (analysis : Analysis.Tezos_repository.t Current.t) =
       stage ~from
         ~child_builds:[ ("src", Lib.Fetch.spec analysis) ]
         [
-          user ~uid:100 ~gid:100;
+          user ~uid:1000 ~gid:1000; 
           workdir "/home/tezos/src";
           copy ~from:(`Build "src") [ "/tezos" ] ~dst:".";
           run ". ./scripts/version.sh";
@@ -92,7 +92,7 @@ let check_precommit_hook ~builder
       stage ~from
         ~child_builds:[ ("src", Lib.Fetch.spec analysis) ]
         [
-          user ~uid:100 ~gid:100;
+          user ~uid:1000 ~gid:1000; 
           workdir "/home/tezos";
           copy ~from:(`Build "src") [ "/tezos" ] ~dst:".";
           run ". ./scripts/version.sh";

--- a/src/stages/lints.ml
+++ b/src/stages/lints.ml
@@ -17,7 +17,8 @@ let sanity_ci ~builder (analysis : Analysis.Tezos_repository.t Current.t) =
           copy ~from:(`Build "build") [ "/dist/" ] ~dst:".";
           run ". ./scripts/version.sh";
           run ". /home/tezos/.venv/bin/activate";
-          run "opam exec -- src/tooling/lint.sh --check-gitlab-ci-yml";
+          run "opam exec -- make -C manifest check";
+          run "opam exec -- scripts/lint.sh --check-gitlab-ci-yml";
         ])
   in
   Lib.Builder.build ~label:"lints:sanity_ci" builder spec
@@ -60,7 +61,7 @@ let misc_checks ~builder (analysis : Analysis.Tezos_repository.t Current.t) =
           env "VIRTUAL_ENV" "/home/tezos/.venv";
           env "PATH" "$VIRTUAL_ENV/bin:$PATH";
           (* checks that all deps of opam packages are already installed *)
-          run "./scripts/opam-check.sh";
+          run "opam exec -- ./scripts/opam-check.sh";
           (* misc linting *)
           run
             "find . ! -path \"./_opam/*\" -name \"*.opam\" -exec opam lint {} \

--- a/src/stages/packaging.ml
+++ b/src/stages/packaging.ml
@@ -17,23 +17,31 @@ let v ~package (tezos_repository : Analysis.Tezos_repository.t) =
     stage ~from
       ~child_builds:[ ("build_src", Lib.Fetch.spec tezos_repository) ]
       [
-        user ~uid:1000 ~gid:1000; 
+        user ~uid:1000 ~gid:1000;
         env "HOME" "/home/tezos";
         workdir "/tezos/";
         copy ~from:(`Build "build_src") [ "/tezos/" ] ~dst:"./";
-        run "./scripts/opam-pin.sh";
-        run "opam depext --yes %s" package;
+        (* from packaging.yml*)
+        run "git init _opam-repo-for-release";
+        run
+          "opam exec -- ./scripts/opam-prepare-repo.sh dev ./ \
+           ./_opam-repo-for-release";
+        run "git -C _opam-repo-for-release add packages";
+        run "git -C _opam-repo-for-release commit -m \"tezos packages\"";
+        (* from opam_template in templates.yml *)
+        run "opam remote add dev-repo ./_opam-repo-for-release";
+        run "opam depext --yes %s.dev" package;
         env "DUNE_CACHE" "enabled";
         env "DUNE_CACHE_TRANSPORT" "direct";
-        run ~cache "opam install --yes %s" package;
-        run ~cache "opam reinstall --yes --with-test %s" package;
+        run ~cache "opam install --yes %s.dev" package;
+        run ~cache "opam reinstall --yes --with-test %s.dev" package;
       ])
 
 let all ~builder (analysis : Tezos_repository.t Current.t) =
   let open Current.Syntax in
   let all_packages =
     let+ analysis = analysis in
-    analysis.bin_packages @ analysis.lib_packages
+    analysis.packages
   in
   Task.list_iter ~collapse_key:"packaging"
     (module struct

--- a/src/stages/packaging.ml
+++ b/src/stages/packaging.ml
@@ -17,7 +17,7 @@ let v ~package (tezos_repository : Analysis.Tezos_repository.t) =
     stage ~from
       ~child_builds:[ ("build_src", Lib.Fetch.spec tezos_repository) ]
       [
-        user ~uid:100 ~gid:100;
+        user ~uid:1000 ~gid:1000; 
         env "HOME" "/home/tezos";
         workdir "/tezos/";
         copy ~from:(`Build "build_src") [ "/tezos/" ] ~dst:"./";

--- a/src/stages/test_liquidity_baking_scripts.ml
+++ b/src/stages/test_liquidity_baking_scripts.ml
@@ -9,7 +9,7 @@ let spec analysis =
     stage ~from
       ~child_builds:[ ("build", build); ("src", Lib.Fetch.spec analysis) ]
       [
-        user ~uid:100 ~gid:100;
+        user ~uid:1000 ~gid:1000; 
         workdir "/home/tezos/src";
         copy ~from:(`Build "src") [ "/tezos/" ] ~dst:".";
         copy ~from:(`Build "build") [ "/dist/" ] ~dst:".";

--- a/src/stages/tezt.ml
+++ b/src/stages/tezt.ml
@@ -12,7 +12,7 @@ let template ~tezt_job analysis =
     stage ~from
       ~child_builds:[ ("build", build); ("src", Lib.Fetch.spec analysis) ]
       [
-        user ~uid:100 ~gid:100;
+        user ~uid:1000 ~gid:1000; 
         workdir "/home/tezos/src";
         copy ~from:(`Build "src") [ "/tezos/" ] ~dst:".";
         copy ~from:(`Build "build") [ "/dist/" ] ~dst:".";

--- a/src/stages/unittest.ml
+++ b/src/stages/unittest.ml
@@ -1,7 +1,7 @@
 open Analysis
 open Lib
 
-let template ?(extra_script = []) ~targets analysis =
+let template ?(extra_script = []) ~name ~targets analysis =
   let build = Build.v analysis in
   let from =
     Variables.docker_image_runtime_build_test_dependencies analysis.version
@@ -10,13 +10,16 @@ let template ?(extra_script = []) ~targets analysis =
     match targets with
     | [] -> []
     | targets ->
-        [ Obuilder_spec.run "opam exec -- make %s" (String.concat " " targets) ]
+        [
+          Obuilder_spec.run "opam exec -- scripts/test_wrapper.sh %s %s" name
+            (String.concat " " targets);
+        ]
   in
   Obuilder_spec.(
     stage ~from
       ~child_builds:[ ("build", build); ("src", Lib.Fetch.spec analysis) ]
       ([
-         user ~uid:1000 ~gid:1000; 
+         user ~uid:1000 ~gid:1000;
          workdir "/home/tezos/src";
          copy ~from:(`Build "src") [ "/tezos/" ] ~dst:".";
          copy ~from:(`Build "build") [ "/dist/" ] ~dst:".";
@@ -30,37 +33,65 @@ let template ?(extra_script = []) ~targets analysis =
 
 let targets =
   [
-    ( "unit:010_PtGRANAD",
+    ( "unit:012_Psithaca",
       [
-        "src/proto_010_PtGRANAD/lib_client.test_proto";
-        "src/proto_010_PtGRANAD/lib_protocol.test_proto";
+        "@@src/proto_012_Psithaca/lib_protocol/test/integration/runtest";
+        "@src/proto_012_Psithaca/lib_protocol/test/integration/consensus/runtest";
+        "@src/proto_012_Psithaca/lib_protocol/test/integration/gas/runtest";
+        "@src/proto_012_Psithaca/lib_protocol/test/integration/michelson/runtest";
+        "@src/proto_012_Psithaca/lib_protocol/test/integration/operations/runtest";
+        "@src/proto_012_Psithaca/lib_protocol/test/pbt/runtest";
+        "@src/proto_012_Psithaca/lib_protocol/test/unit/runtest";
+        "@src/proto_012_Psithaca/lib_benchmark/runtest";
+        "@src/proto_012_Psithaca/lib_client/runtest";
+        "@src/proto_012_Psithaca/lib_plugin/runtest";
+        "@src/proto_012_Psithaca/lib_delegate/runtest";
       ],
       None );
-    ( "unit:011_PtHangz2",
+    ( "unit:013_PtJakart",
       [
-        "src/proto_011_PtHangz2/lib_benchmark/lib_benchmark_type_inference.test_proto";
-        "src/proto_011_PtHangz2/lib_benchmark.test_proto";
-        "src/proto_011_PtHangz2/lib_client.test_proto";
-        "src/proto_011_PtHangz2/lib_protocol.test_proto";
+        "@@src/proto_013_PtJakart/lib_protocol/test/integration/runtest";
+        "@src/proto_013_PtJakart/lib_protocol/test/integration/consensus/runtest";
+        "@src/proto_013_PtJakart/lib_protocol/test/integration/gas/runtest";
+        "@src/proto_013_PtJakart/lib_protocol/test/integration/michelson/runtest";
+        "@src/proto_013_PtJakart/lib_protocol/test/integration/operations/runtest";
+        "@src/proto_013_PtJakart/lib_protocol/test/pbt/runtest";
+        "@src/proto_013_PtJakart/lib_protocol/test/unit/runtest";
+        "@src/proto_013_PtJakart/lib_benchmark/runtest";
+        "@src/proto_013_PtJakart/lib_client/runtest";
+        "@src/proto_013_PtJakart/lib_plugin/runtest";
+        "@src/proto_013_PtJakart/lib_delegate/runtest";
       ],
       None );
     ( "unit:alpha",
       [
-        "src/proto_alpha/lib_benchmark/lib_benchmark_type_inference.test_proto";
-        "src/proto_alpha/lib_benchmark.test_proto";
-        "src/proto_alpha/lib_client.test_proto";
-        "src/proto_alpha/lib_protocol.test_proto";
+        "@@src/proto_alpha/lib_protocol/test/integration/runtest";
+        "@src/proto_alpha/lib_protocol/test/integration/consensus/runtest";
+        "@src/proto_alpha/lib_protocol/test/integration/gas/runtest";
+        "@src/proto_alpha/lib_protocol/test/integration/michelson/runtest";
+        "@src/proto_alpha/lib_protocol/test/integration/operations/runtest";
+        "@src/proto_alpha/lib_protocol/test/pbt/runtest";
+        "@src/proto_alpha/lib_protocol/test/unit/runtest";
+        "@src/proto_alpha/lib_protocol/test/regression/runtest";
+        "@src/proto_alpha/lib_benchmark/runtest";
+        "@src/proto_alpha/lib_client/runtest";
+        "@src/proto_alpha/lib_plugin/runtest";
+        "@src/proto_alpha/lib_delegate/runtest";
       ],
       None );
-    ("unit:non-proto", [ "test-nonproto-unit" ], None);
+    ( "unit:non-proto",
+      [],
+      Some
+        Obuilder_spec.
+          [ run "opam exec -- make test-nonproto-unit test-webassembly" ] );
     ( "unit:js_components",
       [],
       Some
         Obuilder_spec.
           [
             run
-              ". ./scripts/install_build_deps.js.sh && opam exec -- make \
-               test-js";
+              "bash -c \". ./scripts/install_build_deps.js.sh && opam exec -- make \
+               test-js\"";
           ] );
     ( "unit:protocol_compiles",
       [],
@@ -78,7 +109,7 @@ let all ~builder (analysis : Analysis.Tezos_repository.t Current.t) =
          let spec =
            let open Current.Syntax in
            let+ analysis = analysis in
-           template ?extra_script ~targets analysis
+           template ?extra_script ~name ~targets analysis
          in
          Lib.Builder.build ~label:name builder spec)
        targets)

--- a/src/stages/unittest.ml
+++ b/src/stages/unittest.ml
@@ -16,7 +16,7 @@ let template ?(extra_script = []) ~targets analysis =
     stage ~from
       ~child_builds:[ ("build", build); ("src", Lib.Fetch.spec analysis) ]
       ([
-         user ~uid:100 ~gid:100;
+         user ~uid:1000 ~gid:1000; 
          workdir "/home/tezos/src";
          copy ~from:(`Build "src") [ "/tezos/" ] ~dst:".";
          copy ~from:(`Build "build") [ "/dist/" ] ~dst:".";


### PR DESCRIPTION
Currently the octez pipeline is failing when run with the upstream tezos repository. 

I have spent a bit of time to synchronize various parts of the CI so that it again reflects what the gitlab CI does:
- build
- integration tests (python)
- lints
- unit tests
- packaging tests